### PR TITLE
🐛Vererbungskette bei decoratorverwendung nicht zerstören

### DIFF
--- a/packages/react-dnd/package.json
+++ b/packages/react-dnd/package.json
@@ -1,12 +1,12 @@
 {
-	"name": "react-dnd",
-	"version": "3.0.0",
+	"name": "@factro/react-dnd",
+	"version": "3.0.0-pre1",
 	"description": "Drag and Drop for React",
 	"main": "lib/index.js",
 	"types": "lib/index.d.ts",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/react-dnd/react-dnd.git"
+		"url": "https://github.com/schuchertmanagementberatung/react-dnd.git"
 	},
 	"license": "BSD-3-Clause",
 	"scripts": {

--- a/packages/react-dnd/src/decorateHandler.tsx
+++ b/packages/react-dnd/src/decorateHandler.tsx
@@ -34,7 +34,7 @@ export default function decorateHandler<P>({
 	const displayName =
 		DecoratedComponent.displayName || DecoratedComponent.name || 'Component'
 
-	class DragDropContainer extends React.Component<P>
+	class DragDropContainer extends (DecoratedComponent as React.ComponentClass<P>)
 		implements IDndComponent<P, any> {
 		public static DecoratedComponent = DecoratedComponent
 		public static displayName = `${containerDisplayName}(${displayName})`


### PR DESCRIPTION
## Was soll sich durch diesen PR ändern?

Bisher hat das verwenden von den react-dnd Dekoratoren dafür gesorgt, dass die prototyp-kette der Instanz der dekorierten Klasse verworfen wurde. das liegt daran, dass die eingehende Klasse bisher nicht erweitert wurde, sondern eine neue, von der eingehenden unabhängigen Klasse erstellt wurde.

Die Prototyp-Kette sollte nicht unterbrochen werden, damit man sich darauf verlassen kann, dass beim verwenden von Klassen die mit react-dnd-dekoratoren dekoriert sind die Methoden der Basisklasse auch tatsächlich vorhanden sind.

## Wie kann man die Änderungen testen?

- Eine Klasse mit einem der react-dnd Dekoratoren dekorieren
- Feststellen dass die daraus resultierenden Klasseninstanzen weiterhin ihre Methoden kennen

## PR-Checkliste

Diese Checkliste bitte nach Erstellen des PRs abhaken:

- [x] Dieser PR kann **jetzt** gemerged werden (falls nicht, schreib "WIP:" in den Titel).
- [x] Ich habe **alle** Änderungen in diesem PR getestet (insbesondere Funktionstest im Browser!).
- [x] Ich habe diesen PR nochmal **selbst reviewed** (auch auf Buchstabendreher, Typos in Log-Ausgaben, etc.).
- [x] Ich habe den `develop` in meinen Branch gemerged als ich diesen PR angelegt habe.
- [x] Ich habe **keine weiteren Änderungen** hinzugefügt als die oben beschriebenen.
- [x] Ich habe alle **PRs, die mit diesem zusammenhängen**, erwähnt.